### PR TITLE
Fix attempt to apply non-function

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -7,7 +7,9 @@ FUZZ <- NULL; DIFFLIB <- NULL; EXTRACT <- NULL; UTILS <- NULL; BUILTINS <- NULL;
 
 
 .onLoad <- function(libname, pkgname) {
-
+  
+  reticulate::py_config() # search for available python versions
+  
   try({
     if (reticulate::py_available(initialize = FALSE)) {
 


### PR DESCRIPTION
FuzzywuzzyR would always return the error "attempt to apply non-function" when calling a function after loading the library. By running reticulate::py_config() beforehand the correct python environments are discovered and the library works correctly.